### PR TITLE
Fix vimscript load guard, fix g:ncm2_d#... initializations

### DIFF
--- a/autoload/ncm2_d.vim
+++ b/autoload/ncm2_d.vim
@@ -1,13 +1,13 @@
-if exists("")
+if get(s:, 'ncm2_d', 0)
   finish
 endif
 let s:ncm2_d = 1
 
-let g:ncm2_d#dcd_client_bin = get(g:, 'g:ncm2_d#dcd_client_bin', 'dcd-client')
-let g:ncm2_d#dcd_client_args = get(g:, 'g:ncm2_d#dcd_client_args', [''])
-let g:ncm2_d#dcd_server_bin = get(g:, 'g:ncm2_d#dcd_server_bin', 'dcd-server')
-let g:ncm2_d#dcd_server_args = get(g:, 'g:ncm2_d#dcd_server_args', [''])
-let g:ncm2_d#dcd_autostart_server = get(g:, 'g:ncm2#dcd_autostart_server', 1)
+let g:ncm2_d#dcd_client_bin = get(g:, 'ncm2_d#dcd_client_bin', 'dcd-client')
+let g:ncm2_d#dcd_client_args = get(g:, 'ncm2_d#dcd_client_args', [''])
+let g:ncm2_d#dcd_server_bin = get(g:, 'ncm2_d#dcd_server_bin', 'dcd-server')
+let g:ncm2_d#dcd_server_args = get(g:, 'ncm2_d#dcd_server_args', [''])
+let g:ncm2_d#dcd_autostart_server = get(g:, 'ncm2#dcd_autostart_server', 1)
 
 let g:ncm2_d#proc = yarp#py3('ncm2_d')
 


### PR DESCRIPTION
1. Vimscript in autoload/*.vim could get reloaded every time a undefined
function ncm2_d#foobar is called. Undefined function should not happen
normally. But adding a guard stops the script from messing up further
when bad things happen.

2. Replace get(g:, 'g:name', default) with get(g:, 'name', default).
This allows user to define their own g:name config.